### PR TITLE
review %d usage in format strings

### DIFF
--- a/apx/apx-es/src/apx_es_fileManager.c
+++ b/apx/apx-es/src/apx_es_fileManager.c
@@ -529,7 +529,7 @@ static void apx_es_fileManager_parseCmdMsg(apx_es_fileManager_t *self, const uin
                break;
             default:
 #if APX_DEBUG_ENABLE
-               fprintf(stderr, "not implemented cmdType: %d\n", cmdType);
+               fprintf(stderr, "not implemented cmdType: %u\n", cmdType);
 #endif
                break;
 
@@ -583,7 +583,7 @@ static void apx_es_fileManager_parseDataMsg(apx_es_fileManager_t *self, uint32_t
          {
             self->dropMessage = true; //drop message since offsets don't match
 #if APX_DEBUG_ENABLE
-            fprintf(stderr, "[APX_ES_FILEMANAGER] invalid offset (%d), message dropped\n",offset);
+            fprintf(stderr, "[APX_ES_FILEMANAGER] invalid offset (%u), message dropped\n",offset);
 #endif
          }
          else if(self->receiveBufOffset+dataLen<=self->receiveBufLen)
@@ -709,8 +709,8 @@ static int32_t apx_es_processPendingWrite(apx_es_fileManager_t *self)
       if (sendAvail >= (int32_t) RMF_MIN_MSG_LEN)
       {
 #if APX_DEBUG_ENABLE
-         printf("apx_es_processPendingWrite, remain=%d, offset=%d, address=%08X\n",
-               (int) self->fileWriteInfo.remain, (int) self->fileWriteInfo.readOffset, self->fileWriteInfo.writeAddress);
+         printf("apx_es_processPendingWrite, remain=%u, offset=%u, address=%08X\n",
+               self->fileWriteInfo.remain, self->fileWriteInfo.readOffset, self->fileWriteInfo.writeAddress);
 #endif
          uint32_t dataLen;
          uint32_t msgLen;

--- a/apx/client/src/apx_client.c
+++ b/apx/client/src/apx_client.c
@@ -108,7 +108,7 @@ int8_t apx_client_connect_tcp(apx_client_t *self, const char *address, uint16_t 
       retval = msocket_connect(msocket, address, port);
       if (retval != 0)
       {
-         fprintf(stderr, "[apx_client] msocket_connect failed with %d\n",retval);
+         fprintf(stderr, "[apx_client] msocket_connect failed with %d\n",(int)retval);
       }
    }
    else

--- a/apx/common/src/apx_file.c
+++ b/apx/common/src/apx_file.c
@@ -275,14 +275,14 @@ int8_t apx_file_write(apx_file_t *self, const uint8_t *pSrc, uint32_t offset, ui
          result = apx_nodeData_writeDefinitionData(self->nodeData, pSrc, offset, length);
          if (result != 0)
          {
-            APX_LOG_ERROR("[APX_FILE] apx_nodeData_writeDefinitionData failed with %d", result);
+            APX_LOG_ERROR("[APX_FILE] apx_nodeData_writeDefinitionData failed with %d", (int)result);
          }
          break;
       case APX_INDATA_FILE:
          result = apx_nodeData_writeInPortData(self->nodeData, pSrc, offset, length);
          if (result != 0)
          {
-            APX_LOG_ERROR("[APX_FILE] apx_nodeData_writeInPortData failed with %d", result);            
+            APX_LOG_ERROR("[APX_FILE] apx_nodeData_writeInPortData failed with %d", (int)result);
          }
          else
          {
@@ -293,7 +293,7 @@ int8_t apx_file_write(apx_file_t *self, const uint8_t *pSrc, uint32_t offset, ui
          result = apx_nodeData_writeOutPortData(self->nodeData, pSrc, offset, length);
          if (result != 0)
          {
-            APX_LOG_ERROR("[APX_FILE] apx_nodeData_writeOutPortData failed with %d", result);            
+            APX_LOG_ERROR("[APX_FILE] apx_nodeData_writeOutPortData failed with %d", (int)result);
          }
          break;
       default:

--- a/apx/common/src/apx_fileManager.c
+++ b/apx/common/src/apx_fileManager.c
@@ -663,11 +663,11 @@ static void apx_fileManager_fileWriteCmdHandler(apx_fileManager_t *self, apx_fil
          }
          else
          {
-            int8_t result;            
+            int8_t result;
             result = apx_nodeData_writeInPortData(file->nodeData, data, offset, len);
             if (result != 0)
             {
-               APX_LOG_ERROR("[APX_FILE_MANAGER(%s)] apx_nodeData_writeInPortData(%d,%d) failed, file=%s", apx_fileManager_modeString(self), offset, len, file->fileInfo.name);
+               APX_LOG_ERROR("[APX_FILE_MANAGER(%s)] apx_nodeData_writeInPortData(%d,%d) failed, file=%s", apx_fileManager_modeString(self), (int)offset, (int)len, file->fileInfo.name);
             }
             else
             {
@@ -799,7 +799,7 @@ static void apx_fileManager_parseCmdMsg(apx_fileManager_t *self, const uint8_t *
                break;
 
             default:
-               APX_LOG_ERROR("[APX_FILE_MANAGER] not implemented cmdType: %d\n", cmdType);
+               APX_LOG_ERROR("[APX_FILE_MANAGER] not implemented cmdType: %u\n", cmdType);
          }
       }
    }

--- a/apx/common/src/apx_nodeManager.c
+++ b/apx/common/src/apx_nodeManager.c
@@ -167,7 +167,7 @@ void apx_nodeManager_remoteFileAdded(apx_nodeManager_t *self, struct apx_fileMan
             {
                if (nodeData->inPortDataLen != remoteFile->fileInfo.length)
                {
-                  APX_LOG_ERROR("[APX_NODE_MANAGER(%s)] file %s has length %d, expected %d\n", apx_fileManager_modeString(fileManager), remoteFile->fileInfo.name, remoteFile->fileInfo.length, nodeData->inPortDataLen);
+                  APX_LOG_ERROR("[APX_NODE_MANAGER(%s)] file %s has length %u, expected %u\n", apx_fileManager_modeString(fileManager), remoteFile->fileInfo.name, remoteFile->fileInfo.length, nodeData->inPortDataLen);
                }
                else
                {
@@ -222,7 +222,7 @@ void apx_nodeManager_remoteFileWritten(apx_nodeManager_t *self, struct apx_fileM
          }
          else
          {
-            //printf("[APX_NODE_MANAGER(%s)] file updated name=%s, offset=%d, len=%u\n", apx_fileManager_modeString(fileManager), remoteFile->fileInfo.name, offset, length);
+            //printf("[APX_NODE_MANAGER(%s)] file updated name=%s, offset=%u, len=%u\n", apx_fileManager_modeString(fileManager), remoteFile->fileInfo.name, offset, length);
          }
          if (remoteFile->fileType == APX_OUTDATA_FILE)
          {
@@ -516,7 +516,7 @@ static void apx_nodeManager_createNode(apx_nodeManager_t *self, const uint8_t *d
                   //check if length of file is the expected length of our outPortDataLen calculation
                   if (outPortDataLen != (int32_t) outDataFile->fileInfo.length)
                   {
-                     APX_LOG_ERROR("[APX_NODE_MANAGER] length of file %s is %d, expected length was %d\n", fileName, outDataFile->fileInfo.length, outPortDataLen);
+                     APX_LOG_ERROR("[APX_NODE_MANAGER] length of file %s is %u, expected length was %d\n", fileName, outDataFile->fileInfo.length, outPortDataLen);
                   }
                   else
                   {
@@ -529,7 +529,7 @@ static void apx_nodeManager_createNode(apx_nodeManager_t *self, const uint8_t *d
                         nodeData->outPortDirtyFlags = (uint8_t*) malloc(outPortDataLen);
                         assert(nodeData->outPortDirtyFlags);
                         nodeData->outPortDataLen = outPortDataLen;
-                        APX_LOG_INFO("[APX_NODE_MANAGER]%s Server opening client file %s[%d,%d]", debugInfoStr, fileName, outDataFile->fileInfo.address, outDataFile->fileInfo.length);
+                        APX_LOG_INFO("[APX_NODE_MANAGER]%s Server opening client file %s[%u,%u]", debugInfoStr, fileName, outDataFile->fileInfo.address, outDataFile->fileInfo.length);
                         apx_nodeData_setNodeInfo(nodeData, nodeInfo);
                         apx_fileManager_sendFileOpen(fileManager, outDataFile->fileInfo.address);
                      }
@@ -563,7 +563,7 @@ static void apx_nodeManager_createNode(apx_nodeManager_t *self, const uint8_t *d
                if (inDataFile != 0)
                {
                   apx_fileManager_attachLocalPortDataFile(fileManager, inDataFile);
-                  APX_LOG_INFO("[APX_NODE_MANAGER]%s Server created file %s[%d,%d]", debugInfoStr, fileName, inDataFile->fileInfo.address, inDataFile->fileInfo.length);
+                  APX_LOG_INFO("[APX_NODE_MANAGER]%s Server created file %s[%u,%u]", debugInfoStr, fileName, inDataFile->fileInfo.address, inDataFile->fileInfo.length);
                }
                else
                {

--- a/apx/server/src/apx_serverConnection.c
+++ b/apx/server/src/apx_serverConnection.c
@@ -187,12 +187,12 @@ int8_t apx_serverConnection_dataReceived(apx_serverConnection_t *self, const uin
       while(totalParseLen<dataLen)
       {
          uint32_t internalParseLen = 0;
-         uint8_t result;         
+         uint8_t result;
          result = apx_serverConnection_parseMessage(self, pNext, remain, &internalParseLen);
          //check parse result
          if (result == 0)
          {
-            //printf("\tinternalParseLen(%s): %d\n",parseFunc, internalParseLen);
+            //printf("\tinternalParseLen(%s): %u\n",parseFunc, internalParseLen);
             assert(internalParseLen<=dataLen);
             pNext+=internalParseLen;
             totalParseLen+=internalParseLen;

--- a/projects/visual studio/npipe/pipe_client/client.c
+++ b/projects/visual studio/npipe/pipe_client/client.c
@@ -11,7 +11,7 @@ static void onPipeConnected(void *arg)
    uint8_t val;
    npipe_t *pipe = (npipe_t*)arg;
    int8_t result = npipe_send(pipe, greeting, strlen(greeting));
-   printf("npipe_send result=%d\n", result);
+   printf("npipe_send result=%d\n", (int)result);
 }
 
 static int8_t onPipeData(void *arg, const uint8_t *dataBuf, uint32_t dataLen, uint32_t *parseLen)


### PR DESCRIPTION
picky static code analysis complains when using %d and providing a char as argument