### PR TITLE
Refactor apx_clientConnection destruction to keep the sendBuffer unti…

### DIFF
--- a/apx/client/src/apx_clientConnection.c
+++ b/apx/client/src/apx_clientConnection.c
@@ -67,6 +67,11 @@ void apx_clientConnection_destroy(apx_clientConnection_t *self)
          msocket_delete(self->msocket);
       }
 
+      if (self->client != 0)
+      {
+         apx_nodeManager_detachFileManager(&self->client->nodeManager, &self->fileManager);
+      }
+      apx_fileManager_stop(&self->fileManager);
       apx_fileManager_destroy(&self->fileManager);
       adt_bytearray_destroy(&self->sendBuffer);
    }


### PR DESCRIPTION
Refactor apx_clientConnection destruction to keep the sendBuffer until no longer needed

Fixes assert seen during apx_client destroy:
apx/client/src/apx_clientConnection.c:271: apx_clientConnection_getSendBuffer: Assertion `data != 0' failed.