### PR TITLE
Protect DataTriggerTable with new Mutex

### DIFF
--- a/apx/common/inc/apx_nodeInfo.h
+++ b/apx/common/inc/apx_nodeInfo.h
@@ -12,6 +12,12 @@
 #include "apx_portDataMap.h"
 #include "apx_dataTrigger.h"
 #include "apx_nodeData.h"
+#ifdef _WIN32
+#include <Windows.h>
+#else
+#include <pthread.h>
+#endif
+#include "osmacro.h"
 
 //////////////////////////////////////////////////////////////////////////////
 // CONSTANTS AND DATA TYPES
@@ -34,6 +40,7 @@ typedef struct apx_nodeInfo_tag
    uint8_t *providePortFlags; //internal flags for provide ports (used for dirty flags when port are connected/disconnected) (one byte per port)
    uint32_t pendingRequirePortFlags; //number of modified requirePortFlags since last check (this is an optimization to reduce some linear search time)
    uint32_t pendingProvidePortFlags; //number of modified providePortFlags since last check (this is an optimization to reduce some linear search time)
+   MUTEX_T outDataTriggerTableLock;
    apx_dataTriggerTable_t outDataTriggerTable; //trigger table routines
    struct apx_nodeData_tag *nodeData; //weak pointer to associated nodeData
 } apx_nodeInfo_t;

--- a/apx/common/src/apx_nodeInfo.c
+++ b/apx/common/src/apx_nodeInfo.c
@@ -102,6 +102,7 @@ void apx_nodeInfo_create(apx_nodeInfo_t *self, apx_node_t *node)
       {
          APX_LOG_ERROR("[APX_NODE_INFO] (%d) : malloc failed\n", (int) __LINE__);
       }
+      MUTEX_INIT(self->outDataTriggerTableLock);
       apx_dataTriggerTable_create(&self->outDataTriggerTable,self,0,0);
       self->nodeData = (apx_nodeData_t*) 0; //default NULL
    }
@@ -116,7 +117,10 @@ void apx_nodeInfo_destroy(apx_nodeInfo_t *self)
       adt_ary_destroy(&self->provideConnectors);
       apx_portDataMap_destroy(&self->inDataMap);
       apx_portDataMap_destroy(&self->outDataMap);
+      MUTEX_LOCK(self->outDataTriggerTableLock);
       apx_dataTriggerTable_destroy(&self->outDataTriggerTable);
+      MUTEX_UNLOCK(self->outDataTriggerTableLock);
+      MUTEX_DESTROY(self->outDataTriggerTableLock);
       if (self->requirePortFlags != 0)
       {
          free(self->requirePortFlags);

--- a/apx/common/src/apx_nodeManager.c
+++ b/apx/common/src/apx_nodeManager.c
@@ -237,10 +237,10 @@ void apx_nodeManager_remoteFileWritten(apx_nodeManager_t *self, struct apx_fileM
          {
             apx_nodeInfo_t *nodeInfo = remoteFile->nodeData->nodeInfo;
             assert(nodeInfo != 0);
+            MUTEX_LOCK(nodeInfo->outDataTriggerTableLock);
             while (offset < endOffset)
             {
                apx_dataTriggerFunction_t *triggerFunction;
-               MUTEX_LOCK(self->lock);
                triggerFunction = apx_nodeInfo_getTriggerFunction(nodeInfo, offset);
                if (triggerFunction != 0)
                {
@@ -252,8 +252,8 @@ void apx_nodeManager_remoteFileWritten(apx_nodeManager_t *self, struct apx_fileM
                   //fprintf(stderr, "APX_NODE_MANAGER(%s)] no trigger function found for file %s at offset %d\n", apx_fileManager_modeString(fileManager), remoteFile->fileInfo.name, offset);               
                   offset++;
                }
-               MUTEX_UNLOCK(self->lock);
             }
+            MUTEX_UNLOCK(nodeInfo->outDataTriggerTableLock);
          }
       }
    }

--- a/apx/common/src/apx_router.c
+++ b/apx/common/src/apx_router.c
@@ -471,8 +471,10 @@ static void apx_router_postProcessNode(apx_nodeInfo_t *nodeInfo, int8_t debugMod
       int32_t numProvidePorts = adt_ary_length(&nodeInfo->node->providePortList);
       adt_str_t *str = adt_str_new();
 
+      MUTEX_LOCK(nodeInfo->outDataTriggerTableLock);
       for(i=0;i<numProvidePorts;i++)
       {
+
          if (nodeInfo->providePortFlags[i] != 0)
          {
             if (debugMode == APX_DEBUG_2_LOW)
@@ -526,6 +528,7 @@ static void apx_router_postProcessNode(apx_nodeInfo_t *nodeInfo, int8_t debugMod
             }
          }
       }
+      MUTEX_UNLOCK(nodeInfo->outDataTriggerTableLock);
       adt_str_delete(str);
       //clear flags
       memset(nodeInfo->providePortFlags,0,numProvidePorts);


### PR DESCRIPTION
Done in order to secure there is no time window when remote outfile can be written before router has attached all trigger functions