### PR TITLE
Fix initial data sent by server to clients missing late providers

### DIFF
--- a/apx/apx-es/test/test_nodes/ApxNode_ButtonStatus.c
+++ b/apx/apx-es/test/test_nodes/ApxNode_ButtonStatus.c
@@ -33,7 +33,7 @@ static const uint8_t m_inPortInitData[APX_IN_PORT_DATA_LEN]= {
 };
 
 static uint8_t m_inPortdata[APX_IN_PORT_DATA_LEN];
-static uint8_t m_inPortDirtyFlags[APX_IN_PORT_DATA_LEN];
+static uint8_t m_inPortWrittenByProviderFlags[APX_IN_PORT_DATA_LEN];
 static apx_nodeData_t m_nodeData;
 static const char *m_apxDefinitionData=
 "APX/1.2\n"
@@ -56,10 +56,10 @@ static const char *m_apxDefinitionData=
 apx_nodeData_t * ApxNode_Init_ButtonStatus(void)
 {
    memcpy(&m_inPortdata[0], &m_inPortInitData[0], APX_IN_PORT_DATA_LEN);
-   memset(&m_inPortDirtyFlags[0], 0, sizeof(m_inPortDirtyFlags));
+   memset(&m_inPortWrittenByProviderFlags[0], 0, sizeof(m_inPortWrittenByProviderFlags));
    memcpy(&m_outPortdata[0], &m_outPortInitData[0], APX_OUT_PORT_DATA_LEN);
    memset(&m_outPortDirtyFlags[0], 0, sizeof(m_outPortDirtyFlags));
-   apx_nodeData_create(&m_nodeData, "ButtonStatus", (uint8_t*) &m_apxDefinitionData[0], APX_DEFINITON_LEN, &m_inPortdata[0], &m_inPortDirtyFlags[0], APX_IN_PORT_DATA_LEN, &m_outPortdata[0], &m_outPortDirtyFlags[0], APX_OUT_PORT_DATA_LEN);
+   apx_nodeData_create(&m_nodeData, "ButtonStatus", (uint8_t*) &m_apxDefinitionData[0], APX_DEFINITON_LEN, &m_inPortdata[0], &m_inPortWrittenByProviderFlags[0], APX_IN_PORT_DATA_LEN, &m_outPortdata[0], &m_outPortDirtyFlags[0], APX_OUT_PORT_DATA_LEN);
    return &m_nodeData;
 }
 

--- a/apx/apx-es/test/test_nodes/ApxNode_ButtonStatusDirect.c
+++ b/apx/apx-es/test/test_nodes/ApxNode_ButtonStatusDirect.c
@@ -33,7 +33,6 @@ static const uint8_t m_inPortInitData[APX_IN_PORT_DATA_LEN]= {
 };
 
 static uint8_t m_inPortdata[APX_IN_PORT_DATA_LEN];
-static uint8_t m_inPortDirtyFlags[APX_IN_PORT_DATA_LEN];
 static apx_nodeData_t m_nodeData;
 static const char *m_apxDefinitionData=
 "APX/1.2\n"
@@ -56,10 +55,9 @@ static const char *m_apxDefinitionData=
 apx_nodeData_t * ApxNode_Init_ButtonStatusDirect(void)
 {
    memcpy(&m_inPortdata[0], &m_inPortInitData[0], APX_IN_PORT_DATA_LEN);
-   memset(&m_inPortDirtyFlags[0], 0, sizeof(m_inPortDirtyFlags));
    memcpy(&m_outPortdata[0], &m_outPortInitData[0], APX_OUT_PORT_DATA_LEN);
    memset(&m_outPortDirtyFlags[0], 0, sizeof(m_outPortDirtyFlags));
-   apx_nodeData_create(&m_nodeData, "ButtonStatus", (uint8_t*) &m_apxDefinitionData[0], APX_DEFINITON_LEN, &m_inPortdata[0], &m_inPortDirtyFlags[0], APX_IN_PORT_DATA_LEN, &m_outPortdata[0], &m_outPortDirtyFlags[0], APX_OUT_PORT_DATA_LEN);
+   apx_nodeData_create(&m_nodeData, "ButtonStatus", (uint8_t*) &m_apxDefinitionData[0], APX_DEFINITON_LEN, &m_inPortdata[0], NULL, APX_IN_PORT_DATA_LEN, &m_outPortdata[0], &m_outPortDirtyFlags[0], APX_OUT_PORT_DATA_LEN);
    return &m_nodeData;
 }
 

--- a/apx/common/inc/apx_nodeData.h
+++ b/apx/common/inc/apx_nodeData.h
@@ -63,7 +63,7 @@ typedef struct apx_nodeData_tag
    uint32_t outPortDataLen;
    uint8_t *definitionDataBuf;
    uint32_t definitionDataLen;
-   uint8_t *inPortDirtyFlags;
+   uint8_t *inPortSyncedFlags;
    uint8_t *outPortDirtyFlags;
    apx_nodeDataHandlerTable_t handlerTable;
 #ifdef APX_EMBEDDED
@@ -104,7 +104,7 @@ typedef struct ApxWriteBuf16_Tag
 //////////////////////////////////////////////////////////////////////////////
 // GLOBAL FUNCTION PROTOTYPES
 //////////////////////////////////////////////////////////////////////////////
-void apx_nodeData_create(apx_nodeData_t *self, const char *name, uint8_t *definitionBuf, uint32_t definitionDataLen,  uint8_t *inPortDataBuf, uint8_t *inPortDirtyFlags, uint32_t inPortDataLen, uint8_t *outPortDataBuf, uint8_t *outPortDirtyFlags, uint32_t outPortDataLen);
+void apx_nodeData_create(apx_nodeData_t *self, const char *name, uint8_t *definitionBuf, uint32_t definitionDataLen,  uint8_t *inPortDataBuf, uint8_t *inPortSyncedFlags, uint32_t inPortDataLen, uint8_t *outPortDataBuf, uint8_t *outPortDirtyFlags, uint32_t outPortDataLen);
 void apx_nodeData_destroy(apx_nodeData_t *self);
 apx_nodeData_t *apx_nodeData_newRemote(const char *name, bool isWeakRef);
 void apx_nodeData_delete(apx_nodeData_t *self);

--- a/apx/common/inc/apx_nodeData.h
+++ b/apx/common/inc/apx_nodeData.h
@@ -124,6 +124,7 @@ void apx_nodeData_unlockInPortData(apx_nodeData_t *self);
 //DEPRECATED INTERFACE (Regenerate your APX node using latest py-apx code generator)
 void apx_nodeData_outPortDataNotify(apx_nodeData_t *self, uint32_t offset, uint32_t len);
 
+void apx_nodeData_writeInPortDefaultDataIfNotDirty(apx_nodeData_t *self, const uint8_t *src, uint32_t offset, uint32_t len);
 int8_t apx_nodeData_writeInPortData(apx_nodeData_t *self, const uint8_t *src, uint32_t offset, uint32_t len);
 int8_t apx_nodeData_writeOutPortData(apx_nodeData_t *self, const uint8_t *src, uint32_t offset, uint32_t len);
 int8_t apx_nodeData_writeDefinitionData(apx_nodeData_t *self, const uint8_t *src, uint32_t offset, uint32_t len);

--- a/apx/common/inc/apx_nodeManager.h
+++ b/apx/common/inc/apx_nodeManager.h
@@ -59,5 +59,6 @@ void apx_nodeManager_attachLocalNode(apx_nodeManager_t *self, apx_nodeData_t *no
 void apx_nodeManager_attachFileManager(apx_nodeManager_t *self, struct apx_fileManager_tag *fileManager);
 void apx_nodeManager_detachFileManager(apx_nodeManager_t *self, struct apx_fileManager_tag *fileManager);
 void apx_nodeManager_setDebugMode(apx_nodeManager_t *self, int8_t debugMode);
+void apx_nodeManager_populateInDataFile(apx_nodeManager_t *self, apx_nodeData_t *nodeData);
 
 #endif //APX_NODE_MANAGER_H

--- a/apx/common/src/apx_fileManager.c
+++ b/apx/common/src/apx_fileManager.c
@@ -944,15 +944,12 @@ static void apx_fileManager_processOpenFile(apx_fileManager_t *self, const rmf_c
       SPINLOCK_LEAVE(self->lock);
       if (localFile != 0)
       {
-         int32_t bytesToSend = localFile->fileInfo.length;
          if (self->debugInfo != (void*) 0)
          {
             APX_LOG_DEBUG("[APX_FILE_MANAGER] (%p) Client opened %s", self->debugInfo, localFile->fileInfo.name);
          }
-         apx_fileManager_triggerFileUpdatedEvent(self, localFile, 0, bytesToSend);
          if (localFile->nodeData != 0)
          {
-            apx_file_open(localFile);
             if ( localFile->fileType == APX_OUTDATA_FILE )
             {
                apx_nodeData_setOutPortDataFile(localFile->nodeData, localFile);
@@ -964,6 +961,8 @@ static void apx_fileManager_processOpenFile(apx_fileManager_t *self, const rmf_c
                apx_nodeData_setFileManager(localFile->nodeData, self);
             }
          }
+         apx_file_open(localFile); // Open file before sending the full file to secure no updates are missed
+         apx_fileManager_triggerFileUpdatedEvent(self, localFile, 0, localFile->fileInfo.length);
       }
    }
 }

--- a/apx/common/src/apx_nodeData.c
+++ b/apx/common/src/apx_nodeData.c
@@ -265,17 +265,13 @@ int8_t apx_nodeData_readDefinitionData(apx_nodeData_t *self, uint8_t *dest, uint
 int8_t apx_nodeData_readOutPortData(apx_nodeData_t *self, uint8_t *dest, uint32_t offset, uint32_t len)
 {
    assert((offset+len) <= self->outPortDataLen);
-#ifndef APX_EMBEDDED
-   SPINLOCK_ENTER(self->outPortDataLock);
-#endif
+   apx_nodeData_lockOutPortData(self);
    memcpy(dest, &self->outPortDataBuf[offset], len);
    if (self->outPortDirtyFlags != 0)
    {
       memset(&self->outPortDirtyFlags[offset], 0, len);
    }
-#ifndef APX_EMBEDDED
-   SPINLOCK_LEAVE(self->outPortDataLock);
-#endif
+   apx_nodeData_unlockOutPortData(self);
    return 0;
 }
 

--- a/apx/common/src/apx_nodeManager.c
+++ b/apx/common/src/apx_nodeManager.c
@@ -598,9 +598,9 @@ static void apx_nodeManager_createNode(apx_nodeManager_t *self, const uint8_t *d
 
                nodeData->inPortDataBuf = (uint8_t*) malloc(inPortDataLen);
                assert(nodeData->inPortDataBuf);
-               nodeData->inPortDirtyFlags = (uint8_t*) malloc(inPortDataLen);
-               assert(nodeData->inPortDirtyFlags);
-               memset(nodeData->inPortDirtyFlags, 0, inPortDataLen);
+               nodeData->inPortSyncedFlags = (uint8_t*) malloc(inPortDataLen);
+               assert(nodeData->inPortSyncedFlags);
+               memset(nodeData->inPortSyncedFlags, 0, inPortDataLen);
                nodeData->inPortDataLen = inPortDataLen;
                inDataFile = apx_file_newLocalInPortDataFile(nodeData);
                if (inDataFile == 0)
@@ -770,7 +770,7 @@ static bool apx_nodeManager_setNoneDirtyInDataFromDefinition(apx_node_t *node, a
          assert(port != 0);
          packLen = apx_port_getPackLen(port);
          // Only get init data from own definition if no provider is connected
-         if (nodeData->inPortDirtyFlags[offset] == 0)
+         if (nodeData->inPortSyncedFlags[offset] == 0)
          {
             apx_node_fillPortInitData(node, port, portData);
             assert(packLen == (int32_t)adt_bytearray_length(portData));


### PR DESCRIPTION
Concurrency issue was worsened with eaa1ee6 that exposed a larger
time window when provider data could be overwritten with data from
require nodes definition file.